### PR TITLE
Fix github url for remotes with ssh url

### DIFF
--- a/slides/markmaker.py
+++ b/slides/markmaker.py
@@ -184,7 +184,7 @@ try:
         repo = os.environ["REPOSITORY_URL"]
     else:
         repo = subprocess.check_output(["git", "config", "remote.origin.url"])
-    repo = repo.strip().replace("git@github.com:", "https://github.com/")
+    repo = repo.strip().replace("git@github.com:", "https://github.com/").replace(".git", "")
     if "BRANCH" in os.environ:
         branch = os.environ["BRANCH"]
     else:


### PR DESCRIPTION
Consider:
```
➜  slides git:(fix/git-url) git config remote.origin.url
Alias tip: g config remote.origin.url
git@github.com:yurynix/container.training.git
```

The result url before the patch is:
```
https://github.com/Soluto/container.training.git/tree/master/slides/containers/Docker_Overview.md
```

(404)